### PR TITLE
DISCUSS: Add Github actions

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10.13.0-alpine
+
+COPY ../ .
+
+ENTRYPOINT ["/action/entrypoint.sh"]
+
+LABEL "com.github.actions.name"="Chronicler"
+LABEL "com.github.actions.description"=" A better way to write your release notes."
+LABEL "com.github.actions.icon"="edit-2"
+LABEL "com.github.actions.color"="gray-dark"
+

--- a/action/adapter.js
+++ b/action/adapter.js
@@ -1,0 +1,8 @@
+const fs = require('fs')
+const { handleWebhookEvent } = require('../src/helpers/pr')
+
+const event = JSON.parse(
+  fs.readFileSync(process.env.GITHUB_EVENT_PATH, { encoding: 'utf8' })
+)
+
+handleWebhookEvent(event)

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -l
+
+npm ci
+
+GH_TOKEN=$GITHUB_TOKEN APP_NAME=Chronicler node ./action/adapter.js


### PR DESCRIPTION
**Disclaimer: Found this under "Forks". Not my own.  This is NOT meant to be merged, merely discussed.**

Github recently introduced [Actions](https://github.com/features/actions), which might be nice to have your repo automatically update your own Release Notes when you do your own merging.


*Sidenote: It seems the original repository is stale and abandoned (much like newspapers themselves I suppose), you have the most advanced copy of the repository, would you consider maintaining this fork and permitting Issues? (Click Settings -> Enable Issues under Features)*